### PR TITLE
we want to skip loading ramfs if possible

### DIFF
--- a/plat/sg2042/boot.c
+++ b/plat/sg2042/boot.c
@@ -320,6 +320,11 @@ int read_all_img(IO_DEV *io_dev, int dev_num)
 			continue;
 
 		if (io_dev->func.open(boot_file[i].name, FA_READ)) {
+			if (ID_RAMFS) {
+				pr_warn("ramfs open fail, ignore it!\n");
+				continue;
+			}
+
 			pr_err("open %s failed\n", boot_file[i].name);
 			goto close_file;
 		}

--- a/plat/sg2042/boot.c
+++ b/plat/sg2042/boot.c
@@ -333,7 +333,15 @@ int read_all_img(IO_DEV *io_dev, int dev_num)
 			pr_err("get %s info failed\n", boot_file[i].name);
 			goto close_file;
 		}
+
+		/* skip empty file */
+		if (info.fsize == 0) {
+			pr_warn("%s file length zero, skip it!\n", boot_file[i].name);
+			continue;
+		}
+
 		boot_file[i].len = info.fsize;
+
 		if (io_dev->func.read(boot_file, i, info.fsize)) {
 			pr_err("read %s failed\n", boot_file[i].name);
 			goto close_file;

--- a/plat/sg2042/boot.c
+++ b/plat/sg2042/boot.c
@@ -219,8 +219,15 @@ static int handler_img(void* user, const char* section, const char* name,
 		pconfig->fw_name = strdup(value);
 	else if (MATCH("firmware", "addr"))
 		pconfig->fw_addr = strtoul(value, NULL, 16);
-	else if (MATCH("ramfs", "name"))
-		pconfig->ramfs_name =  strdup(value);
+	else if (MATCH("ramfs", "name")) {
+		if (value && strlen(value)) {
+			pconfig->ramfs_name = strdup(value);
+		} else {
+			boot_file[ID_RAMFS].name = NULL;
+			img_name_sd[ID_RAMFS] = NULL;
+			img_name_spi[ID_RAMFS] = NULL;
+		}
+	}
 	else if (MATCH("ramfs", "addr"))
 		pconfig->ramfs_addr = strtoul(value, NULL, 16);
 	else
@@ -309,6 +316,9 @@ int read_all_img(IO_DEV *io_dev, int dev_num)
 	}
 
 	for (int i = 1; i < ID_MAX; i++) {
+		if (boot_file[i].name == NULL)
+			continue;
+
 		if (io_dev->func.open(boot_file[i].name, FA_READ)) {
 			pr_err("open %s failed\n", boot_file[i].name);
 			goto close_file;


### PR DESCRIPTION
the goal of this PR is trying to support uboot boot procedure, and more specific, we want to skip loading ramfs if possible, we provide three ways to achieve this

1) empty file name in riscv64/conf.ini,for ramfs section

[ramfs]
   name =

2) delete file of riscv64/initrd.img in boot partition
3) make riscv64/initrd.img empty (file length == 0) while it could still exist
