### PR TITLE
sg2044: disable mac rx delay on boot.

### DIFF
--- a/plat/sg2044/boot.c
+++ b/plat/sg2044/boot.c
@@ -620,6 +620,8 @@ int boot(void)
 	print_banner();
 	print_core_ctrlreg();
 
+	disable_mac_rxdelay();
+
 #ifdef CONFIG_TPU_SCALAR
 	void *fdt;
 	int core_id;

--- a/plat/sg2044/include/memmap.h
+++ b/plat/sg2044/include/memmap.h
@@ -13,6 +13,10 @@
 #define CLINT_MHART_ID  0x6844001000 // used for identify tp id
 #endif
 
+#define REG_TOP_MISC_CONTROL		0x8
+#define REG_TOP_MISC_CONTROL_ADDR	(TOP_BASE + REG_TOP_MISC_CONTROL)
+#define RGMII0_DISABLE_INTERNAL_DELAY	(1 << 16)
+
 #define REG_DDR_SIZE    0X54
 #define DDR_SIZE_ADDR   (TOP_BASE + REG_DDR_SIZE)
 #define MP0_STATUS	0x380

--- a/plat/sg2044/include/sg_common.h
+++ b/plat/sg2044/include/sg_common.h
@@ -31,6 +31,7 @@ enum cpu_board_type {
 #define RAMFS_OFFSET	0xa000000
 #define TP_SYS_OFFSET	0x10000000
 
+void disable_mac_rxdelay(void);
 uint64_t get_work_mode(void);
 uint64_t get_core_type(void);
 

--- a/plat/sg2044/sg_common.c
+++ b/plat/sg2044/sg_common.c
@@ -26,3 +26,12 @@ uint64_t get_core_type(void)
 	return CORE_64CORE_RV;
 #endif
 }
+
+void disable_mac_rxdelay(void)
+{
+	uint32_t misc_conf;
+
+	misc_conf = mmio_read_32(REG_TOP_MISC_CONTROL_ADDR);
+	misc_conf |= RGMII0_DISABLE_INTERNAL_DELAY;
+	mmio_write_32(REG_TOP_MISC_CONTROL_ADDR, misc_conf);
+}


### PR DESCRIPTION
Since the mac rx delay causes trouble for the external phys, disable it so the kernel and other firmware can be happy.