### PR TITLE
SG2042: Fixbug, wrong dtb used

### DIFF
--- a/lib/sgfat/sgfat.c
+++ b/lib/sgfat/sgfat.c
@@ -43,7 +43,7 @@ static long get_file_size(struct bootdev *bootdev, const char *file)
 	fdev = sgfat->fdev;
 
 	sprintf(fatfs_devid, "%d:", fdev->id);
-	sprintf(fatfs_name, "%d:%s", fdev->id, file);
+	sprintf(fatfs_name, "%d:%s/%s", fdev->id, prefix, file);
 
 	pr_debug("device: %s | %s\n", sgfat->blkdev->device.name, fatfs_name);
 

--- a/plat/sg2042/config.c
+++ b/plat/sg2042/config.c
@@ -51,7 +51,7 @@ int parse_config_file(struct config *cfg)
 	const char *file = "conf.ini";
 
 	size = bdm_get_file_size(file);
-	if (size < 0) {
+	if (size <= 0) {
 		pr_debug("No config file found, using default configurations\n");
 		return -ENOENT;
 	}

--- a/plat/sg2042/plat.c
+++ b/plat/sg2042/plat.c
@@ -203,12 +203,6 @@ static void build_board_info(struct config *cfg)
 	else
 		pr_err("Can not find device tree\n");
 
-#if 0
-	for (int i = 0; i < MAX_CHIP_NUM; i++)
-		for (int j = 0; j < DDR_CHANNEL_NUM; j++)
-			sg2042_board_info.ddr_info[i].ddr_node_name[j] = ddr_node_name[i][j];
-#endif
-
 	for (i = 0; i < MAX_CHIP_NUM; ++i)
 		cfg->ddr[i][0].base = CHIP_ADDR_SPACE * i;
 
@@ -492,9 +486,14 @@ int plat_main(void)
 {
 	print_core_ctrlreg();
 
+	config_init(&cfg);
+
 	build_board_info(&cfg);
 
-	config_init(&cfg);
+	/* setup boot priorities */
+	bdm_set_priority("blk0-sd", 0);
+	bdm_set_priority("mtd1-spifmc", 1);
+	bdm_set_priority("mtd0-spifmc", 2);
 
 	parse_config_file(&cfg);
 	show_config(&cfg);


### PR DESCRIPTION
1. Setup dtb names after config init
2. Add prefix "riscv64" in sgfat lib
3. Setup boot device priority before loading any files

fix #87