### PR TITLE
SG2044: Fix footer "[eof]" not found in EDK II phase

### DIFF
--- a/plat/sg2044/config.c
+++ b/plat/sg2044/config.c
@@ -69,6 +69,7 @@ int parse_config_file(struct config *cfg)
 		return -EINVAL;
 	}
 
+	eof += strlen(tail);
 	*eof = 0;
 
 	if (ini_parse_string((void *)cfg->cfg.addr, handler_img, cfg) < 0)


### PR DESCRIPTION
Set the NULL character after the footer rather than before.