### PR TITLE
Modify the conf.ini content according to SMBIOS specifications

### DIFF
--- a/arch/riscv/boot/conf/sg2044-evb-conf.ini
+++ b/arch/riscv/boot/conf/sg2044-evb-conf.ini
@@ -1,51 +1,31 @@
 [sophgo-config]
-
 [DDR]
 type = LPDDR5x
-data-rate = 8533MT/s
+data-rate = 4266500000
 rank = 2
-vendor = ExampleVendor
 
 [CPU]
-type = SG2044
-frequency = 2.5GHz
-l1-i-cache-size = 64KiB
-l1-d-cache-size = 64KiB
-l2-cache-size = 2MiB
-l3-cache-size = 64MiB
-part-number = 1234-5678
-serial-number = ABCD12345678
+processor_version = C920
+frequency = 2800000000
+l1-i-cache-size = 65536
+l1-d-cache-size = 65536
+l2-cache-size = 2097152
+l3-cache-size = 67108864
 
 [BIOS Information]
-version = EDK2 version 1.0
-vendor = SOPHGO
-UUID = 123e4567-e89b-12d3-a456-426614174000
-
-[chassis]
-name = ExampleChassis
-vendor = ChassisVendor
-part-number = 9876-5432
-serial-number = ZXCV0987
+bios_version = 1.0
+bios_vendor = SOPHGO
+date = 2024-12-25
+time = 00:00:00
 
 [board]
-name = ExampleBoard
-vendor = BoardVendor
+product_name = SG2044_EVB
 version = 1.1
-mfg-data = 2023-05-01 14:30:00
-part-number = 1357-2468
-serial-number = QWER5678
 
 [product]
-name = ExampleProduct
-vendor = ProductVendor
-version = 2.0
-manufacturer = ProductManufacturer
-part-number = 1122-3344
+product_name = SG2044
+version = 1.0
+manufacturer = SOPHGO
 serial-number = TYUI7890
-
-[Date Time]
-date = 2023-10-31
-time = 14:45:00
-
+uuid = 123e4567-e89b-12d3-a456-426614174000
 [eof]
-


### PR DESCRIPTION
- Remove the chassis-related content.
- Update the values for DDR, CPU, and cache sections according to SMBIOS specifications.
- Standardize the casing (uppercase/lowercase) in conf.ini.