### PR TITLE
bm1690: cli_loop(0) will cause zsbl into cmdline.

### DIFF
--- a/plat/sg2044/plat.c
+++ b/plat/sg2044/plat.c
@@ -291,7 +291,6 @@ int plat_main(void)
 		modify_dtb(&cfg);
 	} else {
 		show_config(&cfg);
-		cli_loop(0);
 	}
 
 	dynamic_info.magic = FW_DYNAMIC_INFO_MAGIC_VALUE;


### PR DESCRIPTION
In PCIe mode, zsbl should directly jump to the next level to continue execution.