### PR TITLE
Strip CR/LF line endings in INI file parsing

### DIFF
--- a/include/lib/libc/string.h
+++ b/include/lib/libc/string.h
@@ -20,5 +20,6 @@ char *strstr(const char *haystack, const char *needle);
 char *strcat(char *dest, const char *src);
 char *strcpy(char *dest, const char *src);
 char *strncpy(char *dest, const char *src, size_t count);
+size_t strcspn(const char *s, const char *reject);
 
 #endif

--- a/lib/ini/ini.c
+++ b/lib/ini/ini.c
@@ -288,6 +288,7 @@ static char* ini_reader_string(char* str, int num, void* stream) {
 	}
 
 	*strp = '\0';
+	str[strcspn(str, "\r\n")] = '\0';
 	ctx->ptr = ctx_ptr;
 	ctx->num_left = ctx_num_left;
 	return str;

--- a/lib/libc/string.c
+++ b/lib/libc/string.c
@@ -300,3 +300,21 @@ char *strcat (char *__restrict s1,
 	return s;
 }
 
+size_t strcspn(const char *s, const char *reject) {
+	unsigned char table[256] = {0};
+	const unsigned char *r = (const unsigned char *)reject;
+
+	while (*r) {
+	    table[*r] = 1;
+	    r++;
+	}
+	const unsigned char *p = (const unsigned char *)s;
+	while (*p) {
+	    if (table[*p]) {
+		break;
+	    }
+	    p++;
+	}
+
+	return (size_t)(p - (const unsigned char *)s);
+}


### PR DESCRIPTION
 - Add function “strcspn” to string library.

 - Ensure that the ini file edited under Windows/Linux can be parsed normally.