### PR TITLE
SG2044: preserve devicetree load behavior

### DIFF
--- a/plat/sg2044/config.c
+++ b/plat/sg2044/config.c
@@ -25,6 +25,10 @@ static int handler_img(void* user, const char* section, const char* name,
 		pconfig->dtb.name = strdup(value);
 	else if (MATCH("devicetree", "addr"))
 		pconfig->dtb.addr = strtoul(value, NULL, 16);
+	if (MATCH("devicetree-overlay", "name"))
+		pconfig->dtbo.name = strdup(value);
+	else if (MATCH("devicetree-overlay", "addr"))
+		pconfig->dtbo.addr = strtoul(value, NULL, 16);
 	else if (MATCH("kernel", "name"))
 		pconfig->kernel.name = strdup(value);
 	else if (MATCH("kernel", "addr"))

--- a/plat/sg2044/config.h
+++ b/plat/sg2044/config.h
@@ -117,12 +117,14 @@ struct config {
 	struct boot_file sbi;
 	struct boot_file kernel;
 	struct boot_file dtb;
+	struct boot_file dtbo;
 	struct boot_file ramfs;
 	struct boot_file cfg;
 
 	struct boot_file sbi_sig;
 	struct boot_file kernel_sig;
 	struct boot_file dtb_sig;
+	struct boot_file dtbo_sig;
 	struct boot_file ramfs_sig;
 
 	struct akcipher_ctx akcipher_ctx;


### PR DESCRIPTION
As previous commit change the devicetree loading method when setting external devicetree and treats it as an overlay file. Add a [devicetree-overlay] item to restore the system, so it will not break the configuration compatible.