### PR TITLE
Add riscv gcc 15.1 toolchain compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -794,7 +794,7 @@ $(TARGET).bin: $(TARGET).elf
 $(TARGET).dis: $(TARGET).elf
 	$(Q)echo "  DS      $@"
 	$(Q)$(READELF) -e $< > $@
-	$(Q)$(OBJDUMP) -D $< >> $@
+	$(Q)$(OBJDUMP) -d $< >> $@
 
 targets := $(TARGET).elf
 

--- a/arch/riscv/src/builtin_dtb.S
+++ b/arch/riscv/src/builtin_dtb.S
@@ -1,5 +1,6 @@
 	.global	__dtb_start
 	.global __dtb_end
+	.section .rodata
 	.balign	8
 __dtb_start:
 	.incbin	CONFIG_BUILTIN_DTB


### PR DESCRIPTION
 - Changed objdump option from -D to -d in the Makefile and placed DTB in .rodata section to avoid core dump with 15.1 toolchain.

 - The -D option causes objdump to crash when disassembling non-code sections, while -d restricts disassembly to code sections only and works correctly.