### PR TITLE
plat: sg2042: skip bootargs modification when no ramfs configured

### DIFF
--- a/plat/sg2042/plat.c
+++ b/plat/sg2042/plat.c
@@ -453,11 +453,11 @@ static int modify_bootargs(struct config *cfg)
 	char bootargs[256] = {0};
 	char append[128] = {0};
 
-        /* Do not clobber DTB chosen/bootargs when no ramfs is configured.
-         * sg2260 handles this correctly; apply the same guard here.
-         */
-        if (!cfg->ramfs.name)
-                return 0;
+	/* Do not clobber DTB chosen/bootargs when no ramfs is configured.
+	 * sg2260 handles this correctly; apply the same guard here.
+	 */
+	if (!cfg->ramfs.name)
+		return 0;
 
 	fdt = (void *)cfg->dtb.addr;
 	ramfs = (void*)cfg->ramfs.addr;

--- a/plat/sg2042/plat.c
+++ b/plat/sg2042/plat.c
@@ -453,6 +453,12 @@ static int modify_bootargs(struct config *cfg)
 	char bootargs[256] = {0};
 	char append[128] = {0};
 
+        /* Do not clobber DTB chosen/bootargs when no ramfs is configured.
+         * sg2260 handles this correctly; apply the same guard here.
+         */
+        if (!cfg->ramfs.name)
+                return 0;
+
 	fdt = (void *)cfg->dtb.addr;
 	ramfs = (void*)cfg->ramfs.addr;
 	sprintf(append, "root=/dev/ram0 rw initrd=0x%lx,32M", (unsigned long)ramfs);


### PR DESCRIPTION
When no ramfs is specified in conf.ini, modify_bootargs() unconditionally appends 'root=/dev/ram0' to the DTB chosen/bootargs node, silently overriding any root device specified in the DTB. This breaks non-ramfs boot configurations such as NVMe root devices.

The sg2260 platform already handles this correctly by checking cfg->ramfs.name before modifying bootargs. Apply the same guard to sg2042 for consistency.

Fixes symptom reported in sophgo/bootloader-riscv#71.
Hardware-verified on Milk-V Pioneer SG2042 (64-core, 128GB DDR4).